### PR TITLE
Restricted permissions to edit other user's posts by before_action.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user
-
+  before_action :ensure_current_user, {only: [:edit, :update, :destroy]}
 
   def index
     @posts = Post.all.order(created_at: :desc)
@@ -63,5 +63,13 @@ class PostsController < ApplicationController
     @post.destroy
     flash[:notice] = "the list has been deleted."
     redirect_to("/posts/index")
+  end
+
+  def ensure_current_user
+    @post = Post.find_by(id: params[:id])
+      if @post.user_id != @current_user.id
+        flash[:notice] = "You don't have the authority to."
+        redirect_to("/posts/index")
+      end
   end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,10 +14,12 @@
      <div class="post-time">
        <%= @post.created_at %>
      </div>
+     <% if @post.user_id == @current_user.id %>
      <div class="post-menus">
        <%= link_to("EDIT", "/posts/#{@post.id}/edit") %>
        <%= link_to("DELETE", "/posts/#{@post.id}/destroy", {method:"post"}) %>
      </div>
+     <% end %>
    </div>
   </div>
 </div>


### PR DESCRIPTION
Added before_action called "ensure_current_user, {only: [:edit, :update, :destroy]}" to protect posts from editing by other users.

Also changed that only current_user can see the edit & delete link on posts